### PR TITLE
Transparent animations

### DIFF
--- a/agvis/static/js/ContourLayer.js
+++ b/agvis/static/js/ContourLayer.js
@@ -17,10 +17,13 @@ varying float vValue;
 uniform sampler2D uColormapSampler;
 uniform float uScaleMin;
 uniform float uScaleMax;
+uniform float uOpacity;
 
 void main() {
 	float value = (vValue - uScaleMin) / (uScaleMax - uScaleMin);
-	gl_FragColor = texture2D(uColormapSampler, vec2(value, 0.0));
+	vec4 color = texture2D(uColormapSampler, vec2(value, 0.0));
+	color.a *= uOpacity; // Apply opacity to the color
+	gl_FragColor = color;
 }
 `;
 
@@ -166,6 +169,8 @@ function renderContour(canvas, { size, bounds, project, needsProjectionUpdate })
 		},
 	});
 
+	const uOpacity = this._opacity;
+
     if(this._render) {
         gl.viewport(0, 0, gl.canvas.width, gl.canvas.height);
         gl.enable(gl.BLEND);
@@ -179,6 +184,7 @@ function renderContour(canvas, { size, bounds, project, needsProjectionUpdate })
             uScaleMax,
             uProjection,
             uColormapSampler,
+			uOpacity,
         });
         twgl.drawBufferInfo(gl, aIndicesBufferInfo, gl.TRIANGLES);
 
@@ -199,6 +205,7 @@ L.ContourLayer = L.CanvasLayer.extend({
 		this._variableRelIndices = null;
 		this._uScaleMin = 0.8;
 		this._uScaleMax = 1.2;
+		this._opacity = 1.0;
 		this._cache = new WeakMap();
         this._render = true;
 
@@ -236,7 +243,12 @@ L.ContourLayer = L.CanvasLayer.extend({
     toggleRender() {
         this._render = !this._render;
         console.log("Contour rendering: ", this._render);
-    }
+    },
+
+	updateOpacity(opacity) {
+        this._opacity = opacity;
+		this.redraw();
+    },
 
 });
 

--- a/agvis/static/js/ContourLayer.js
+++ b/agvis/static/js/ContourLayer.js
@@ -22,7 +22,7 @@ uniform float uOpacity;
 void main() {
 	float value = (vValue - uScaleMin) / (uScaleMax - uScaleMin);
 	vec4 color = texture2D(uColormapSampler, vec2(value, 0.0));
-	color.a *= uOpacity; // Apply opacity to the color
+	color.a *= uOpacity;
 	gl_FragColor = color;
 }
 `;

--- a/agvis/static/js/PlaybackControl.js
+++ b/agvis/static/js/PlaybackControl.js
@@ -76,9 +76,14 @@ let PlaybackControl = L.Control.extend({
         opacitybar.max = 1;
         opacitybar.step = 0.01;
         opacitybar.value = 1.0;
-        opacitybar.style.marginRight = '20px';
+
+        let opacityspan = L.DomUtil.create('span', '', rdiv);
+        opacityspan.innerHTML = " 1.00 ";
+        opacityspan.style.marginRight = '20px';
 
         opacitybar.oninput = function(e) {
+            a = Number(e.target.value).toFixed(2);
+            opacityspan.innerHTML = ' ' + a + ' ';
             win.contourLayer.updateOpacity(e.target.value);
         }
 

--- a/agvis/static/js/PlaybackControl.js
+++ b/agvis/static/js/PlaybackControl.js
@@ -68,7 +68,7 @@ let PlaybackControl = L.Control.extend({
         rdiv.style.float = "right";
 
         let opacitylabel = L.DomUtil.create('span', '', rdiv);
-        opacitylabel.innerHTML = "Opacity";
+        opacitylabel.innerHTML = "Opacity ";
         let opacitybar = L.DomUtil.create('input', '', rdiv);
         this.opacitybar = opacitybar;
         opacitybar.type = "range";
@@ -78,17 +78,17 @@ let PlaybackControl = L.Control.extend({
         opacitybar.value = 1.0;
 
         let opacityspan = L.DomUtil.create('span', '', rdiv);
-        opacityspan.innerHTML = " 1.00 ";
+        opacityspan.innerHTML = " 100 ";
         opacityspan.style.marginRight = '20px';
 
         opacitybar.oninput = function(e) {
-            a = Number(e.target.value).toFixed(2);
+            a = Math.round(e.target.value*100);
             opacityspan.innerHTML = ' ' + a + ' ';
             win.contourLayer.updateOpacity(e.target.value);
         }
 
         let playbackspeedlabel = L.DomUtil.create('span', '', rdiv);
-        playbackspeedlabel.innerHTML = "Speed";
+        playbackspeedlabel.innerHTML = "Speed ";
         let playbackspeedrange = L.DomUtil.create('input', '', rdiv);
         playbackspeedrange.type = "range";
         playbackspeedrange.value = 2;

--- a/agvis/static/js/PlaybackControl.js
+++ b/agvis/static/js/PlaybackControl.js
@@ -5,6 +5,7 @@ let PlaybackControl = L.Control.extend({
 
     initialize: function(win, options) {
         this.win = win;
+        this.opacitybar = null;
         this.playbackbar = null;
 
         if (options) L.Util.setOptions(this, options);
@@ -66,6 +67,23 @@ let PlaybackControl = L.Control.extend({
         let rdiv = L.DomUtil.create('div', '', div);
         rdiv.style.float = "right";
 
+        let opacitylabel = L.DomUtil.create('span', '', rdiv);
+        opacitylabel.innerHTML = "Opacity";
+        let opacitybar = L.DomUtil.create('input', '', rdiv);
+        this.opacitybar = opacitybar;
+        opacitybar.type = "range";
+        opacitybar.min = 0;
+        opacitybar.max = 1;
+        opacitybar.step = 0.01;
+        opacitybar.value = 1.0;
+        opacitybar.style.marginRight = '20px';
+
+        opacitybar.oninput = function(e) {
+            win.contourLayer.updateOpacity(e.target.value);
+        }
+
+        let playbackspeedlabel = L.DomUtil.create('span', '', rdiv);
+        playbackspeedlabel.innerHTML = "Speed";
         let playbackspeedrange = L.DomUtil.create('input', '', rdiv);
         playbackspeedrange.type = "range";
         playbackspeedrange.value = 2;
@@ -142,4 +160,6 @@ let PlaybackControl = L.Control.extend({
             this.playbackbar.value = value;
         }
     }
+
+
 });


### PR DESCRIPTION
I created an opacity bar that appears in the playback div so the nodes can be seen underneath. It updates the opacity no matter what state the simulation is in. Let me know if the opacity bar should be stacked instead of in front of the speed bar, since I think it makes the whole container bigger. Also, I thought it was unnecessary to show the value of the opacity next to the bar, but that is an easy fix if it should be added.

Here are examples of the opacity bar in use:
![i1](https://github.com/CURENT/agvis/assets/112013308/26f5bbf7-9cfe-467b-8f75-b92178bc4477)
![i2](https://github.com/CURENT/agvis/assets/112013308/14e43232-6327-446c-9fc7-e41347d507c4)
![i3](https://github.com/CURENT/agvis/assets/112013308/1adb9231-1476-4f7c-b367-014fefdaa81d)
![i4](https://github.com/CURENT/agvis/assets/112013308/6a21a30a-1f0f-4ec1-9c2c-c729b89ef5d0)

Regards,
Zack
