### PR TITLE
Updated max zoom

### DIFF
--- a/agvis/static/js/Window.js
+++ b/agvis/static/js/Window.js
@@ -122,7 +122,7 @@ class Window {
 
         this.map = L.map(this.map_name, {
             minZoom: 3,
-            maxZoom: 10,
+            maxZoom: 18,
 			zoomSnap: 0.01,
             center: [40, -100],
             zoom: 5,


### PR DESCRIPTION
This was thankfully a simple fix! It turns out I was editing the wrong map options (which might be a tell of code quality concerns involving how the map is instantiated, but that is an issue for another day). As long as it works. 

The max zoom was set to 10, which is nearly half of what leaflet is capable of. All I had to do was update it to 18, and I believe it is powerful enough for the capability we are looking for. 